### PR TITLE
Bump kemitix maven tiles from 0.9.0 to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <java.version>8</java.version>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
+        <kemitix-maven-tiles.version>2.1.3</kemitix-maven-tiles.version>
         <kemitix-checkstyle.version>4.1.1</kemitix-checkstyle.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
@@ -100,7 +100,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                        <tile>net.kemitix.tiles:all:${kemitix-tiles.version}</tile>
+                        <tile>net.kemitix.tiles:all:${kemitix-maven-tiles.version}</tile>
                         <!--<tile>net.kemitix.tiles:pmd-strict:${kemitix-tiles.version}</tile>-->
                         <tile>net.kemitix.checkstyle:tile:${kemitix-checkstyle.version}</tile>
                     </tiles>


### PR DESCRIPTION
`kemtiix-maven-tiles` brings jacoco 0.8.3 which is compatible with JDK 11.