### PR TITLE
Remove deprecated junit-platform-surefire-provider

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -53,20 +53,20 @@ pipeline {
                 }
             }
         }
-        // stage('Build Java 11') {
-        //     steps {
-        //         withMaven(maven: 'maven', jdk: 'JDK 11') {
-        //             sh "${mvn} clean verify -Djava.version=11"
-        //         }
-        //     }
-        // }
-        // stage('Build Java 12') {
-        //     steps {
-        //         withMaven(maven: 'maven', jdk: 'JDK 12') {
-        //             sh "${mvn} clean verify -Djava.version=12"
-        //         }
-        //     }
-        // }
+        stage('Build Java 11') {
+            steps {
+                withMaven(maven: 'maven', jdk: 'JDK 11') {
+                    sh "${mvn} clean verify -Djava.version=11"
+                }
+            }
+        }
+        stage('Build Java 12') {
+            steps {
+                withMaven(maven: 'maven', jdk: 'JDK 12') {
+                    sh "${mvn} clean verify -Djava.version=12"
+                }
+            }
+        }
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
         <kemitix-maven-tiles.version>2.1.3</kemitix-maven-tiles.version>
         <kemitix-checkstyle.version>4.1.1</kemitix-checkstyle.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
-        <junit-platform-surefire-provider.version>1.3.2</junit-platform-surefire-provider.version>
         <pitest-maven-plugin.version>1.4.3</pitest-maven-plugin.version>
         <pitest-junit5-plugin.version>0.8</pitest-junit5-plugin.version>
         <lombok.version>1.18.4</lombok.version>
@@ -110,13 +109,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit-platform-surefire-provider.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.pitest</groupId>

--- a/src/main/java/net/kemitix/gitdb/GitDBBranch.java
+++ b/src/main/java/net/kemitix/gitdb/GitDBBranch.java
@@ -33,6 +33,13 @@ import net.kemitix.mon.result.Result;
 public interface GitDBBranch {
 
     /**
+     * The name of the branch.
+     *
+     * @return the branch name
+     */
+    Result<String> name();
+
+    /**
      * Lookup a value for the key.
      *
      * @param key the key to lookup

--- a/src/main/java/net/kemitix/gitdb/impl/GitDBBranchImpl.java
+++ b/src/main/java/net/kemitix/gitdb/impl/GitDBBranchImpl.java
@@ -34,7 +34,7 @@ import org.eclipse.jgit.lib.Repository;
 import java.util.function.Function;
 
 /**
- * API for interacting with a branch in a GirDB.
+ * API for interacting with a branch in a GitDB.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
@@ -71,6 +71,11 @@ class GitDBBranchImpl implements GitDBBranch {
             final String userEmailAddress
     ) {
         return Result.ok(new GitDBBranchImpl(branchRef, gitDBRepo, userName, userEmailAddress, branchRef.getName()));
+    }
+
+    @Override
+    public Result<String> name() {
+        return Result.ok(name);
     }
 
     @Override

--- a/src/test/java/net/kemitix/gitdb/test/GitDBTest.java
+++ b/src/test/java/net/kemitix/gitdb/test/GitDBTest.java
@@ -392,4 +392,17 @@ class GitDBTest implements WithAssertions {
                 );
     }
 
+    @Test
+    void selectBranch_branchExists_thenBranchName() throws Throwable {
+        //given
+        final Path dbDir = dirDoesNotExist();
+        final Result<GitDB> gitDb = gitDB(dbDir);
+        //when
+        final Result<Maybe<String>> branchName = gitDb.flatMap(selectBranch("master"))
+                .flatMap(branch -> Result.swap(branch.map(GitDBBranch::name)));
+        //then
+        assertThat(branchName.orElseThrow().toOptional()).as("Branch name is master")
+                .contains("refs/heads/master");
+    }
+
 }


### PR DESCRIPTION
* Remove deprecated junit-platform-surefire-provider

Fixes #38 

* [jenkins] re-enable jdk 11 and 12 test builds

jdk 13 is incompatible due to a transiative incompatibility in
spotbugs plugin from kemitix-maven-tiles.